### PR TITLE
feat/category-schema-localization - update category schema to support localized slug field

### DIFF
--- a/backend/src/api/category/content-types/category/schema.json
+++ b/backend/src/api/category/content-types/category/schema.json
@@ -24,10 +24,6 @@
         }
       }
     },
-    "slug": {
-      "type": "uid",
-      "targetField": "name"
-    },
     "articles": {
       "type": "relation",
       "relation": "oneToMany",
@@ -41,6 +37,15 @@
           "localized": true
         }
       }
+    },
+    "slug": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string",
+      "required": true
     }
   }
 }

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -1259,13 +1259,19 @@ export interface ApiCategoryCategory extends Schema.CollectionType {
           localized: true;
         };
       }>;
-    slug: Attribute.UID<'api::category.category', 'name'>;
     articles: Attribute.Relation<
       'api::category.category',
       'oneToMany',
       'api::article.article'
     >;
     description: Attribute.Text &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    slug: Attribute.String &
+      Attribute.Required &
       Attribute.SetPluginOptions<{
         i18n: {
           localized: true;


### PR DESCRIPTION
…
- Replace UID slug field with localized string slug field in category schema
- Update generated TypeScript types to reflect localized slug attribute
- Enable i18n localization for category slug field with required validation