### PR TITLE
feat/i18n-partner-brand-messages - add new translation keys for partners and brands sections

### DIFF
--- a/frontend/messages/ar.json
+++ b/frontend/messages/ar.json
@@ -40,11 +40,13 @@
     "industries": "الصناعات",
     "contactUs": "تواصل معنا",
     "allLocations": "جميع المواقع",
-    "crossBorderSolutionsToGCCFrom": "من خلال الحدود المتقاطعة للمنطقة المركزية العربية"
+    "crossBorderSolutionsToGCCFrom": "من خلال الحدود المتقاطعة للمنطقة المركزية العربية",
+    "stayTunedForMorePartners": "تابعنا للمزيد من الشركاء!",
+    "stayTunedForMoreBrands": "تابعنا للمزيد من العلامات التجارية!"
   },
   "LocaleSwitcher": {
-    "en": "English (UK)",
-    "tr": "Turkish",
+    "en": "English",
+    "tr": "Türkçe",
     "zh-CN": "中文",
     "ar": "العربية",
     "language": "اللغة"

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -40,11 +40,13 @@
     "industries": "Industries",
     "contactUs": "Contact Us",
     "allLocations": "All Locations",
-    "crossBorderSolutionsToGCCFrom": "Cross-Border Solutions to GCC from"
+    "crossBorderSolutionsToGCCFrom": "Cross-Border Solutions to GCC from",
+    "stayTunedForMorePartners": "Stay tuned for more partners!",
+    "stayTunedForMoreBrands": "Stay tuned for more brands!"
   },
   "LocaleSwitcher": {
-    "en": "English (UK)",
-    "tr": "Turkish",
+    "en": "English",
+    "tr": "Türkçe",
     "zh-CN": "中文",
     "ar": "العربية",
     "language": "Language"

--- a/frontend/messages/tr.json
+++ b/frontend/messages/tr.json
@@ -40,11 +40,13 @@
     "industries": "Endüstriler",
     "contactUs": "İletişime Geçin",
     "allLocations": "Tüm Konumlar",
-    "crossBorderSolutionsToGCCFrom": "GCC’ye Yönelik Sınır Ötesi Çözümler -"
+    "crossBorderSolutionsToGCCFrom": "GCC’ye Yönelik Sınır Ötesi Çözümler -",
+    "stayTunedForMorePartners": "Daha fazla iş ortakımız için takip edin!",
+    "stayTunedForMoreBrands": "Daha fazla markamız için takip edin!"
   },
   "LocaleSwitcher": {
-    "en": "English (UK)",
-    "tr": "Turkish",
+    "en": "English",
+    "tr": "Türkçe",
     "zh-CN": "中文",
     "ar": "العربية",
     "language": "Dil"

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -40,11 +40,13 @@
     "industries": "行业",
     "contactUs": "联系我们",
     "allLocations": "所有位置",
-    "crossBorderSolutionsToGCCFrom": "通过GCC的跨境解决方案"
+    "crossBorderSolutionsToGCCFrom": "通过GCC的跨境解决方案",
+    "stayTunedForMorePartners": "敬请期待更多合作伙伴！",
+    "stayTunedForMoreBrands": "敬请期待更多品牌！"
   },
   "LocaleSwitcher": {
-    "en": "English (UK)",
-    "tr": "Turkish",
+    "en": "English",
+    "tr": "Türkçe",
     "zh-CN": "中文",
     "ar": "العربية",
     "language": "语言"


### PR DESCRIPTION


- Add stayTunedForMorePartners translation key across all locales (ar, en, tr, zh-CN)
- Add stayTunedForMoreBrands translation key across all locales for empty state messaging
- Update LocaleSwitcher language display names from English descriptions to native language names
- Standardize English display from "English (UK)" to "English" and Turkish from "Turkish" to "Türkçe"